### PR TITLE
Add item-level `<itunes:image>` and `<itunes:summary>` tags.

### DIFF
--- a/podcast.xml
+++ b/podcast.xml
@@ -32,6 +32,8 @@ layout: null
             <itunes:episode>{{ post.episode }}</itunes:episode>
             <itunes:episodeType>{{ post.episodeType }}</itunes:episodeType>
             <itunes:explicit>{{ post.explicit }}</itunes:explicit>
+            <itunes:image href='{{ post.cover | default: site.podcast.logo | absolute_url }}'/>
+            <itunes:summary><![CDATA[{{ post.content | xml_escape | strip_newlines }}]]></itunes:summary>
             <link>{{ post.url | absolute_url }}</link>
             <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
             <itunes:duration>{{ post.length | xml_escape }}</itunes:duration>


### PR DESCRIPTION
This PR introduces two very minor improvements:

1. Adds an additional `<itunes:image>` tag at the `<item>` level, which improves compliance with iTunes podcast XML.
2. Adds the `<itunes:summary>` tag at the `<item>` level, allowing the use of `<![CDATA[]]>` for richer text formatting.

I found these improvements helpful for improving the feed when submitting to podcast networks and directories for indexing.